### PR TITLE
Multiple streams in pi_cuda

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -473,7 +473,10 @@ pi_result enqueueEventWait(pi_queue queue, pi_event event) {
   // for native events, the cuStreamWaitEvent call is used.
   // This makes all future work submitted to stream wait for all
   // work captured in event.
-  return PI_CHECK_ERROR(cuStreamWaitEvent(queue->get(), event->get(), 0));
+  if (queue->get() != event->get_queue()->get()) {
+    return PI_CHECK_ERROR(cuStreamWaitEvent(queue->get(), event->get(), 0));
+  }
+  return PI_SUCCESS;
 }
 
 _pi_program::_pi_program(pi_context ctxt)

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -511,6 +511,7 @@ pi_result _pi_event::release() {
   return PI_SUCCESS;
 }
 
+// TODO joe: re-add Ruyman's hack here properly
 // makes all future work submitted to queue wait for all work captured in event.
 pi_result enqueueEventWait(pi_queue queue, pi_event event) {
   // for native events, the cuStreamWaitEvent call is used.

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -25,6 +25,8 @@
 #include <mutex>
 #include <regex>
 
+static const char *useAltStreamStr = std::getenv("PI_CUDA_USE_ALT_STREAM");
+
 namespace {
 std::string getCudaVersionString() {
   int driver_version = 0;
@@ -2204,7 +2206,6 @@ pi_result cuda_piQueueCreate(pi_context context, pi_device device,
     }
 
     // TODO document this environment variable
-    static const char *useAltStreamStr = std::getenv("PI_CUDA_USE_ALT_STREAM");
     bool useAltStream = useAltStreamStr ? (std::stoi(useAltStreamStr) == 1) : false;
 
     if (useAltStream) {

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -2380,8 +2380,6 @@ pi_result cuda_piEnqueueMemBufferRead(pi_queue command_queue, pi_mem buffer,
 pi_result cuda_piEventsWait(pi_uint32 num_events, const pi_event *event_list) {
 
   try {
-    assert(num_events != 0);
-    assert(event_list);
     if (num_events == 0) {
       return PI_INVALID_VALUE;
     }

--- a/sycl/plugins/cuda/pi_cuda.hpp
+++ b/sycl/plugins/cuda/pi_cuda.hpp
@@ -620,7 +620,6 @@ struct _pi_kernel {
     // be the last argument.
     args_index_t indices_ = { implicitOffsetArgs_ };
     pi_uint32 offsetSum{0};
-    size_t nArgs{0}; // excluding implicitOffsetArgs, never actually used (yet)
     size_t sizeAccum{0};
 
     std::uint32_t implicitOffsetArgs_[3] = {0, 0, 0};
@@ -635,11 +634,7 @@ struct _pi_kernel {
 
       // TODO - this struct is reused as-is for every kernel, so need to reset
       // somehow. Could commandeer clear_local_size() but this will do for now
-      if (index == 0) {
-        sizeAccum = 0;
-        nArgs = 0;
-      }
-      if (index + 1 > nArgs) nArgs = index + 1;
+      if (index == 0) sizeAccum = 0;
 
       // Update the stored value for the argument
       std::memcpy(&storage_[sizeAccum], arg, size);

--- a/sycl/plugins/cuda/pi_cuda.hpp
+++ b/sycl/plugins/cuda/pi_cuda.hpp
@@ -386,10 +386,18 @@ struct _pi_queue {
   pi_queue_properties properties_;
   std::atomic_uint32_t refCount_;
   std::atomic_uint32_t eventCount_;
+  bool useAltStream_{false};
 
   _pi_queue(CUstream stream, CUstream altStream, _pi_context *context, _pi_device *device,
             pi_queue_properties properties)
-      : stream_{stream}, altStream_{altStream}, context_{context}, device_{device},
+      : _pi_queue(stream, context, device, properties) {
+    altStream_ = altStream;
+    useAltStream_ = true;
+  }
+
+  _pi_queue(CUstream stream, _pi_context *context, _pi_device *device,
+            pi_queue_properties properties)
+      : stream_{stream}, context_{context}, device_{device},
         properties_{properties}, refCount_{1}, eventCount_{0} {
     cuda_piContextRetain(context_);
     cuda_piDeviceRetain(device_);
@@ -402,7 +410,9 @@ struct _pi_queue {
 
   native_type get() const noexcept { return stream_; };
 
-  native_type get_alt_stream() const noexcept { return altStream_; };
+  native_type get_alt_stream() const noexcept { return useAltStream_ ? altStream_ : stream_; };
+
+  bool use_alt_stream() const noexcept { return useAltStream_; };
 
   _pi_context *get_context() const { return context_; };
 

--- a/sycl/plugins/cuda/pi_cuda.hpp
+++ b/sycl/plugins/cuda/pi_cuda.hpp
@@ -402,7 +402,7 @@ struct _pi_queue {
 
   native_type get() const noexcept { return stream_; }; // TODO what about memStream_?
 
-  native_type get_mem() const noexcept { return memStream_; };
+  native_type get_alt_stream() const noexcept { return memStream_; };
 
   _pi_context *get_context() const { return context_; };
 

--- a/sycl/plugins/cuda/pi_cuda.hpp
+++ b/sycl/plugins/cuda/pi_cuda.hpp
@@ -607,17 +607,13 @@ struct _pi_kernel {
     using args_index_t = std::array<void *, MAX_PARAM_BYTES>;
     args_t storage_;
     args_size_t paramSizes_;
-    args_index_t indices_;
+    // By filling indices_ with implicit offset args first, we ensure it will always
+    // be the last argument.
+    args_index_t indices_ = { implicitOffsetArgs_ };
     pi_uint32 offsetSum{0};
     size_t nArgs{0}; // excluding implicitOffsetArgs, never actually used (yet)
 
     std::uint32_t implicitOffsetArgs_[3] = {0, 0, 0};
-
-    arguments() {
-      // By filling with implicit offset args first, we ensure it will always
-      // be the last argument.
-      indices_.fill(&implicitOffsetArgs_);
-    }
 
     /// Adds an argument to the kernel.
     /// If the argument existed before, it is replaced.
@@ -648,11 +644,11 @@ struct _pi_kernel {
       std::memcpy(implicitOffsetArgs_, implicitOffset, size);
     }
 
-    void clear_local_size() { offsetSum = 0; }
+    inline void clear_local_size() noexcept { offsetSum = 0; }
 
-    const args_index_t &get_indices() const noexcept { return indices_; }
+    inline const args_index_t &get_indices() const noexcept { return indices_; }
 
-    pi_uint32 get_local_size() const { return offsetSum; }
+    inline pi_uint32 get_local_size() const noexcept { return offsetSum; }
   } args_;
 
   _pi_kernel(CUfunction func, CUfunction funcWithOffsetParam, const char *name,

--- a/sycl/plugins/cuda/pi_cuda.hpp
+++ b/sycl/plugins/cuda/pi_cuda.hpp
@@ -380,16 +380,16 @@ struct _pi_queue {
   using native_type = CUstream;
 
   native_type stream_;
-  native_type memStream_;
+  native_type altStream_;
   _pi_context *context_;
   _pi_device *device_;
   pi_queue_properties properties_;
   std::atomic_uint32_t refCount_;
   std::atomic_uint32_t eventCount_;
 
-  _pi_queue(CUstream stream, CUstream memStream, _pi_context *context, _pi_device *device,
+  _pi_queue(CUstream stream, CUstream altStream, _pi_context *context, _pi_device *device,
             pi_queue_properties properties)
-      : stream_{stream}, memStream_{memStream}, context_{context}, device_{device},
+      : stream_{stream}, altStream_{altStream}, context_{context}, device_{device},
         properties_{properties}, refCount_{1}, eventCount_{0} {
     cuda_piContextRetain(context_);
     cuda_piDeviceRetain(device_);
@@ -400,9 +400,9 @@ struct _pi_queue {
     cuda_piDeviceRelease(device_);
   }
 
-  native_type get() const noexcept { return stream_; }; // TODO what about memStream_?
+  native_type get() const noexcept { return stream_; };
 
-  native_type get_alt_stream() const noexcept { return memStream_; };
+  native_type get_alt_stream() const noexcept { return altStream_; };
 
   _pi_context *get_context() const { return context_; };
 
@@ -419,13 +419,13 @@ typedef void (*pfn_notify)(pi_event event, pi_int32 eventCommandStatus,
                            void *userData);
 /// PI Event mapping to CUevent
 ///
-struct _pi_event { // TODO map to stream here for stream vs memStream?
+struct _pi_event {
 public:
   using native_type = CUevent;
 
   pi_result record();
 
-  pi_result wait(); // _pi_event->wait() is host blocking!
+  pi_result wait();
 
   pi_result start();
 

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1768,6 +1768,7 @@ pi_result ExecCGCommand::SetKernelParamsAndLaunch(
       break;
     }
     case kernel_param_kind_t::kind_std_layout: {
+      // TODO - clarify in documentation the use of piKernelSetArg
       Plugin.call<PiApiKind::piKernelSetArg>(Kernel, NextTrueIndex, Arg.MSize,
                                              Arg.MPtr);
       break;

--- a/xptifw/CMakeLists.txt
+++ b/xptifw/CMakeLists.txt
@@ -50,11 +50,13 @@ set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 
 add_subdirectory(src)
 
+if(0)
 add_custom_target(check-xptifw)
 
 add_subdirectory(unit_test)
 add_subdirectory(samples/basic_collector)
 add_subdirectory(samples/syclpi_collector)
+endif()
 
 # The tests in basic_test are written using TBB, so these tests are enabled
 # only if TBB has been enabled.


### PR DESCRIPTION
This PR enables two streams for a single `pi_queue`. We use one for running kernels and the other for memcpy operations.

At present, the enqueuing of waits is still suboptimal. All events are waited on both streams. It doesn't seem to produce much overhead.

This functionality is enabled via the environment variable `PI_CUDA_USE_ALT_STREAM=1`.

